### PR TITLE
Add BLTouch and MKS-PWC pin definitions

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -106,8 +106,11 @@
 //
 #define POWER_LOSS_PIN                      PA2   // PW_DET
 #define PS_ON_PIN                           PA3   // PW_OFF
-
-#define LED_PIN                             PB2
+#define SUICIDE_PIN PB2     // Enable MKSPWC support
+#define KILL_PIN PA2     // Enable MKSPWC support
+#define KILL_PIN_INVERTING true     // Enable MKSPWC support
+#define SERVO0_PIN                          PA8   // Enable BLTOUCH support
+//#define LED_PIN                             PB2
 
 //
 // SD Card


### PR DESCRIPTION
Adds pin definitions for the MKS PWC module for auto off as well as for the BLTouch servo pin header