### PR TITLE
Have Nano v1.2 specific pins off by default

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -112,10 +112,11 @@
 //
 #define POWER_LOSS_PIN                      PA2   // PW_DET
 #define PS_ON_PIN                           PA3   // PW_OFF
-#define SUICIDE_PIN PB2     // Enable MKSPWC support
-#define KILL_PIN PA2     // Enable MKSPWC support
-#define KILL_PIN_INVERTING true     // Enable MKSPWC support
-#define SERVO0_PIN                          PA8   // Enable BLTOUCH support
+//#define SUICIDE_PIN PB2     // Enable MKSPWC support ROBIN NANO v1.2 ONLY
+//#define KILL_PIN PA2     // Enable MKSPWC support ROBIN NANO v1.2 ONLY
+//#define KILL_PIN_INVERTING true     // Enable MKSPWC support ROBIN NANO v1.2 ONLY
+//#define SERVO0_PIN                          PA8   // Enable BLTOUCH support ROBIN NANO v1.2 ONLY
+
 //#define LED_PIN                             PB2
 
 //


### PR DESCRIPTION
The nano v1.1 has different pin connections than the v1.2 causing them to error if they are defined. This should fix the problems they have while also leaving the entries in for v1.2 users to enable