### PR TITLE
Optional SDIO clock, fixing printer halt for printers with PWC

### DIFF
--- a/Marlin/src/HAL/STM32F1/sdio.h
+++ b/Marlin/src/HAL/STM32F1/sdio.h
@@ -100,7 +100,8 @@
 #define SDIO_DATA_TIMEOUT                    100U           /* Read data transfer timeout */
 #define SDIO_WRITE_TIMEOUT                   200U           /* Write data transfer timeout */
 
-#define SDIO_CLOCK                           4500000       /* 4.5 MHz */
+#define SDIO_CLOCK                           18000000      /* 18 MHz */
+//#define SDIO_CLOCK                           4500000       /* 4.5 MHz */  // Testing, use if printer is drifting position during long prints. May cause printer halt error.
 
 // ------------------------
 // Types

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -259,7 +259,8 @@ millis_t max_inactive_time, // = 0
 
 void setup_killpin() {
   #if HAS_KILL
-    SET_INPUT_PULLUP(KILL_PIN);
+    if (!KILL_PIN_INVERTING) SET_INPUT_PULLUP(KILL_PIN);
+    else SET_INPUT(KILL_PIN);
   #endif
 }
 
@@ -521,7 +522,9 @@ inline void manage_inactivity(const bool ignore_stepper_queue=false) {
     // -------------------------------------------------------------------------------
     static int killCount = 0;   // make the inactivity button a bit less responsive
     const int KILL_DELAY = 750;
-    if (!READ(KILL_PIN))
+    if (!READ(KILL_PIN) && !KILL_PIN_INVERTING)
+      killCount++;
+    else if (READ(KILL_PIN) && KILL_PIN_INVERTING)
       killCount++;
     else if (killCount > 0)
       killCount--;

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -1036,6 +1036,9 @@
 #ifndef KILL_PIN
   #define KILL_PIN -1
 #endif
+#ifndef KILL_PIN_INVERTING
+  #define KILL_PIN_INVERTING false
+#endif
 #ifndef SUICIDE_PIN
   #define SUICIDE_PIN -1
 #endif


### PR DESCRIPTION
Noticed some users were having PRINTER HALT issues with the new lower clock. User's with print head drift issues during long prints can go into the sdio file and test with the lower clock speed.