### PR TITLE
Fix error with two extruders & one nozzle

### DIFF
--- a/Marlin/src/ui/src/draw_preHeat.cpp
+++ b/Marlin/src/ui/src/draw_preHeat.cpp
@@ -43,7 +43,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event)
 					thermalManager.start_watching_hotend(uiCfg.curSprayerChoose);
 				}
 			}
-			#if EXTRUDERS >= 2
+			#if !defined(SINGLENOZZLE) && EXTRUDERS >= 2
 			else
 			{
 				if((int)thermalManager.temp_hotend[uiCfg.curSprayerChoose].target > (HEATER_1_MAXTEMP- (WATCH_TEMP_INCREASE + TEMP_HYSTERESIS + 1)))


### PR DESCRIPTION
Compile failed with SINGLENOZZLE and EXTRUDERS = 2, because the UI was trying to draw preheat settings for 2 heaters when there is actually only 1 heater