### PR TITLE
Avoid build break on missing qr_encode.h

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_cloud_bind.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_cloud_bind.cpp
@@ -33,7 +33,7 @@
 #include "../../../../MarlinCore.h"
 #include "../../../../module/temperature.h"
 
-#include "qr_encode.h"
+#include "QR_Encode.h"
 
 extern lv_group_t * g;
 static lv_obj_t * scr;


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

The build is breaking with "fatal error: qr_encode.h: No such file or directory" due to an incorrect file case. The correct file name listed at https://github.com/MKS-Sean/qr_encode/blob/master is `QR_Encode.h`.

I'm proposing the code change here, but it is also possible to change the file case at https://github.com/MKS-Sean/qr_encode/ .

### Benefits

Corrects the build.

### Configurations



### Related Issues

Fixes #124

Signed-off-by: Willian Rampazzo <willianr@gmail.com>