### PR TITLE
Update draw_pause_message.cpp

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_pause_message.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_pause_message.cpp
@@ -35,7 +35,7 @@
 
 void lv_draw_pause_message(const PauseMessage msg) {
   switch (msg) {
-    case PAUSE_MESSAGE_PAUSING:  clear_cur_ui(); lv_draw_dialog(DIALOG_PAUSE_MESSAGE_PAUSING); break;
+    case PAUSE_MESSAGE_PARKING:  clear_cur_ui(); lv_draw_dialog(DIALOG_PAUSE_MESSAGE_PAUSING); break;
     case PAUSE_MESSAGE_CHANGING: clear_cur_ui(); lv_draw_dialog(DIALOG_PAUSE_MESSAGE_CHANGING); break;
     case PAUSE_MESSAGE_UNLOAD:   clear_cur_ui(); lv_draw_dialog(DIALOG_PAUSE_MESSAGE_UNLOAD); break;
     case PAUSE_MESSAGE_WAITING:  clear_cur_ui(); lv_draw_dialog(DIALOG_PAUSE_MESSAGE_WAITING); break;


### PR DESCRIPTION
PAUSE_MESSAGE_PAUSING not defined it's called PAUSE_MESSAGE_PARKING in pause.h

### Requirements
Needed for Filament_runout Sensor
* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
