### PR TITLE
Update pins_MKS_ROBIN_NANO_V2.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -215,8 +215,8 @@
     #define MKS_TEST_PS_ON_PIN                PB2   // PW_OFF
   #endif
 #else
-  //#define POWER_LOSS_PIN                      PA2   // PW_DET
-  //#define PS_ON_PIN                           PB2   // PW_OFF
+  #define POWER_LOSS_PIN                      PA2   // PW_DET It's needed if you don't use TFT_LVGL_UI don't undefine it
+  #define PS_ON_PIN                           PB2   // PW_OFF It's needed if you don't use TFT_LVGL_UI don't undefine it
   #define FIL_RUNOUT_PIN                      PA4
   #define FIL_RUNOUT2_PIN                     PE6
 #endif


### PR DESCRIPTION
#else
  #define POWER_LOSS_PIN                      PA2   // PW_DET It's needed if you don't use TFT_LVGL_UI don't undefine it
  #define PS_ON_PIN                                PB2   // PW_OFF It's needed if you don't use TFT_LVGL_UI don't undefine it
  #define FIL_RUNOUT_PIN                      PA4
  #define FIL_RUNOUT2_PIN                     PE6
#endif

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
