### PR TITLE
Add Menu for tuning TouchMi sensor (Hotends.fr)

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_level_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_level_settings.cpp
@@ -35,7 +35,8 @@ enum {
   ID_LEVEL_RETURN = 1,
   ID_LEVEL_POSITION,
   ID_LEVEL_COMMAND,
-  ID_LEVEL_ZOFFSET
+  ID_LEVEL_ZOFFSET,
+  ID_LEVEL_TOUCHMI         
 };
 
 static void event_handler(lv_obj_t *obj, lv_event_t event) {
@@ -60,16 +61,26 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
         lv_draw_auto_level_offset_settings();
         break;
     #endif
+    #if ENABLED(TOUCH_MI_PROBE)
+      case ID_LEVEL_TOUCHMI:
+        lv_clear_level_settings();
+        lv_draw_touchmi_settings();
+        break;
+    #endif
   }
 }
 
 void lv_draw_level_settings(void) {
+ 
   scr = lv_screen_create(LEVELING_PARA_UI, machine_menu.LevelingParaConfTitle);
   lv_screen_menu_item(scr, machine_menu.LevelingManuPosConf, PARA_UI_POS_X, PARA_UI_POS_Y, event_handler, ID_LEVEL_POSITION, 0);
   lv_screen_menu_item(scr, machine_menu.LevelingAutoCommandConf, PARA_UI_POS_X, PARA_UI_POS_Y * 2, event_handler, ID_LEVEL_COMMAND, 1);
   #if HAS_BED_PROBE
     lv_screen_menu_item(scr, machine_menu.LevelingAutoZoffsetConf, PARA_UI_POS_X, PARA_UI_POS_Y * 3, event_handler, ID_LEVEL_ZOFFSET, 2);
-  #endif
+   #endif
+  #if ENABLED(TOUCH_MI_PROBE)
+    lv_screen_menu_item(scr, machine_menu.LevelingTouchmiConf, PARA_UI_POS_X, PARA_UI_POS_Y * 4, event_handler, ID_LEVEL_TOUCHMI, 3);
+   #endif
   lv_screen_menu_item_return(scr, event_handler, ID_LEVEL_RETURN);
 }
 
@@ -79,5 +90,4 @@ void lv_clear_level_settings() {
   #endif
   lv_obj_del(scr);
 }
-
 #endif // HAS_TFT_LVGL_UI

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.cpp
@@ -39,8 +39,7 @@ enum {
   ID_TM_SAVE,
   ID_TM_TEST,
   ID_H_RETURN
-  //#define ID_H_OFF_XY   7
-};
+ };
 
 static void event_handler(lv_obj_t * obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
@@ -76,13 +75,18 @@ void lv_draw_touchmi_settings(void) {
   lv_big_button_create(scr, "F:/bmp_set.bin", machine_menu.TouchmiSave, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_TM_SAVE);
   lv_big_button_create(scr, "F:/bmp_in.bin", machine_menu.TouchmiTest, BTN_X_PIXEL * 3 + INTERVAL_V * 4,titleHeight, event_handler, ID_TM_TEST);
   lv_big_button_create(scr, "F:/bmp_return.bin", common_menu.text_back, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_H_RETURN);
+
+  
+  zOffsetText = lv_label_create(scr, 290, TITLE_YPOS, nullptr);
+  disp_z_offset_value_TM();
 }
 
 void disp_z_offset_value_TM() {
-	char buf[20];
-
-	ZERO(buf);
-	sprintf_P(buf, PSTR("offset Z: %.3f"), (double)TERN(HAS_BED_PROBE, probe.offset.z, 0));
+  char buf[20];
+  #if HAS_BED_PROBE
+   char str_1[16];
+  #endif
+  sprintf_P(buf, PSTR("offset Z: %s mm"), TERN(HAS_BED_PROBE, dtostrf(probe.offset.z, 1, 3, str_1), "0"));
   lv_label_set_text(zOffsetText, buf);
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.cpp
@@ -86,9 +86,10 @@ void disp_z_offset_value_TM() {
   #if HAS_BED_PROBE
    char str_1[16];
   #endif
-  sprintf_P(buf, PSTR("offset Z: %s mm"), TERN(HAS_BED_PROBE, dtostrf(probe.offset.z, 1, 3, str_1), "0"));
+  sprintf_P(buf, PSTR("offset Z: %s mm"), TERN(HAS_BED_PROBE, dtostrf(probe.offset.z, 1, 2, str_1), "0"));
   lv_label_set_text(zOffsetText, buf);
 }
+
 
 void lv_clear_touchmi_settings() { 
   #if HAS_ROTARY_ENCODER

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.cpp
@@ -1,0 +1,96 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "../../../../inc/MarlinConfigPre.h"
+
+#if HAS_TFT_LVGL_UI
+
+#include "../../../../MarlinCore.h"
+#include "draw_ui.h"
+#include "../../../../gcode/queue.h"
+#include "../../../../module/probe.h"
+
+
+extern lv_group_t * g;
+static lv_obj_t * scr, * zOffsetText;
+
+enum {
+  ID_TM_INIT = 1,
+  ID_TM_ZOFFSETPOS,
+  ID_TM_ZOFFSETNEG,
+  ID_TM_SAVE,
+  ID_TM_TEST,
+  ID_H_RETURN
+  //#define ID_H_OFF_XY   7
+};
+
+static void event_handler(lv_obj_t * obj, lv_event_t event) {
+  if (event != LV_EVENT_RELEASED) return;
+  switch (obj->mks_obj_id) {
+    case ID_TM_INIT:
+      queue.inject_P(PSTR("M851 Z0\nG28\nG1 Z0 F200\nM211 S0"));
+      break;
+    case ID_TM_ZOFFSETPOS:
+      queue.inject_P(PSTR("M290 Z0.1"));
+      break;
+    case ID_TM_ZOFFSETNEG:
+      queue.inject_P(PSTR("M290 Z-0.1"));
+      break;
+    case ID_TM_SAVE:
+      queue.inject_P(PSTR("M211 S1\nM500\nG28 X Y"));
+      break;
+    case ID_TM_TEST:
+      queue.inject_P(PSTR("G28\nG1 Z0"));
+      break;
+    case ID_H_RETURN:
+      lv_clear_touchmi_settings();
+      lv_draw_return_ui();
+      break;
+
+  }
+}
+
+void lv_draw_touchmi_settings(void) {
+  scr = lv_screen_create(TOUCHMI_UI);
+  lv_big_button_create(scr, "F:/bmp_speed0.bin", machine_menu.TouchmiInit, INTERVAL_V, titleHeight, event_handler, ID_TM_INIT);
+  lv_big_button_create(scr, "F:/bmp_zAdd.bin", machine_menu.TouchmiOffsetpos, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_TM_ZOFFSETPOS);
+  lv_big_button_create(scr, "F:/bmp_zDec.bin", machine_menu.TouchmiOffsetneg, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_TM_ZOFFSETNEG);
+  lv_big_button_create(scr, "F:/bmp_set.bin", machine_menu.TouchmiSave, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_TM_SAVE);
+  lv_big_button_create(scr, "F:/bmp_in.bin", machine_menu.TouchmiTest, BTN_X_PIXEL * 3 + INTERVAL_V * 4,titleHeight, event_handler, ID_TM_TEST);
+  lv_big_button_create(scr, "F:/bmp_return.bin", common_menu.text_back, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_H_RETURN);
+}
+
+void disp_z_offset_value_TM() {
+	char buf[20];
+
+	ZERO(buf);
+	sprintf_P(buf, PSTR("offset Z: %.3f"), (double)TERN(HAS_BED_PROBE, probe.offset.z, 0));
+  lv_label_set_text(zOffsetText, buf);
+}
+
+void lv_clear_touchmi_settings() { 
+  #if HAS_ROTARY_ENCODER
+    if (gCfgItems.encoder_enable) lv_group_remove_all_objs(g);
+  #endif
+  lv_obj_del(scr);
+}
+
+#endif // HAS_TFT_LVGL_UI

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_touchmi_settings.h
@@ -22,13 +22,14 @@
 #pragma once
 
 #ifdef __cplusplus
-  extern "C" { /* C-declarations for C++ */
+extern "C" { /* C-declarations for C++ */
 #endif
 
-extern void lv_draw_level_settings(void);
 extern void lv_draw_touchmi_settings(void);
-extern void lv_clear_level_settings();
+extern void lv_clear_touchmi_settings();
+extern void disp_z_offset_value_TM();
 
+//extern void disp_temp_ready_print();
 #ifdef __cplusplus
-  } /* C-declarations for C++ */
+} /* C-declarations for C++ */
 #endif

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
@@ -932,6 +932,13 @@ void GUI_RefreshPage() {
         disp_z_offset_value();
       }
       break;
+
+    case TOUCHMI_UI:
+      if (temps_update_flag) {
+        temps_update_flag = false;
+        disp_z_offset_value_TM();
+      }
+      break;
     default: break;
   }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
@@ -76,6 +76,7 @@
 #include "draw_baby_stepping.h"
 #include "draw_keyboard.h"
 #include "draw_encoder_settings.h"
+#include "draw_touchmi_settings.h"
 
 #include "../../../../inc/MarlinConfigPre.h"
 
@@ -273,6 +274,7 @@ typedef enum {
   TEMP_UI,
   SET_UI,
   ZERO_UI,
+  TOUCHMI_UI,
   SPRAYER_UI,
   MACHINE_UI,
   LANGUAGE_UI,

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_en.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_en.h
@@ -102,6 +102,13 @@
 #define LEVELING_MANUAL_POS_EN          "Manual leveling coordinate settings"
 #define LEVELING_AUTO_COMMAND_EN        "AutoLeveling command settings"
 #define LEVELING_AUTO_ZOFFSET_EN        "Nozzle-to-probe offsets settings"
+#define LEVELING_TOUCHMI_EN             "Settings-TouchMi-Probe"
+#define TM_INIT_EN                         "Init"
+#define TM_ZOFFSETPOS_EN                   "Zoffset+"
+#define TM_ZOFFSETNEG_EN                   "Zoffset-"
+#define TM_SAVE_EN                         "Save"
+#define TM_TEST_EN                         "Test"
+
 
 #define LEVELING_PARA_CONF_TITLE_EN     "leveling setting"
 #define AUTO_LEVELING_ENABLE_EN         "Enable auto leveling"

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_ru.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_ru.h
@@ -291,7 +291,12 @@
 #define LEVELING_MANUAL_POS_RU          "настройки координат для уровня"
 #define LEVELING_AUTO_COMMAND_RU        "настройки комманд увтоуровня"
 #define LEVELING_AUTO_ZOFFSET_RU        "координаты смещения сопла"
-
+#define LEVELING_TOUCHMI_RU             "Settings-TouchMi-Probe"
+#define TM_INIT_RU                         "Init"
+#define TM_ZOFFSETPOS_RU                   "Zoffset+"
+#define TM_ZOFFSETNEG_RU                   "Zoffset-"
+#define TM_SAVE_RU                         "Save"
+#define TM_TEST_RU                         "Test"
 #define MACHINE_CONFIG_TITLE_RU         "Hастройки принтера>настройки притера"
 #define MAXFEEDRATE_CONF_RU             "настройки максимальной скорости"
 #define ACCELERATION_CONF_RU            "настройки ускорений"

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_s_cn.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_s_cn.h
@@ -87,7 +87,12 @@
 #define LEVELING_MANUAL_POS_CN        "手动调平坐标设置"
 #define LEVELING_AUTO_COMMAND_CN      "自动调平指令设置"
 #define LEVELING_AUTO_ZOFFSET_CN      "挤出头与调平开关偏移设置"
-
+#define LEVELING_TOUCHMI_CN           "Settings-TouchMi-Probe"
+#define TM_INIT_CN                       "Init"
+#define TM_ZOFFSETPOS_CN                 "Zoffset+"
+#define TM_ZOFFSETNEG_CN                 "Zoffset-"
+#define TM_SAVE_CN                       "Save"
+#define TM_TEST_CN                       "Test"
 #define LEVELING_PARA_CONF_TITLE_CN   "调平参数"
 #define AUTO_LEVELING_ENABLE_CN       "自动调平"
 #define BLTOUCH_LEVELING_ENABLE_CN    "启动BLtouch"

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_t_cn.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_Language_t_cn.h
@@ -87,6 +87,12 @@
 #define LEVELING_MANUAL_POS_T_CN        "手動調平坐標設置"
 #define LEVELING_AUTO_COMMAND_T_CN      "自動調平指令設置"
 #define LEVELING_AUTO_ZOFFSET_T_CN      "擠出頭與調平開關偏移設置"
+#define LEVELING_TOUCHMI_T_CN           "Settings-TouchMi-Probe"
+#define TM_INIT_T_CN                       "Init"
+#define TM_ZOFFSETPOS_T_CN                 "Zoffset+"
+#define TM_ZOFFSETNEG_T_CN                 "Zoffset-"
+#define TM_SAVE_T_CN                       "Save"
+#define TM_TEST_T_CN                       "Test"
 
 #define LEVELING_PARA_CONF_TITLE_T_CN   "調平參數"
 #define AUTO_LEVELING_ENABLE_T_CN       "自動調平"

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_multi_language.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_multi_language.cpp
@@ -58,6 +58,7 @@ tool_menu_def                tool_menu;
 MachinePara_menu_def         MachinePara_menu;
 pause_msg_def                pause_msg_menu;
 eeprom_def                   eeprom_menu;
+touchmi_menu_def             touchmi_menu;
 
 machine_common_def machine_menu;
 void machine_setting_disp() {
@@ -123,8 +124,8 @@ void machine_setting_disp() {
     machine_menu.LevelingParaConf        = LEVELING_PARA_CONF_CN;
     machine_menu.LevelingManuPosConf     = LEVELING_MANUAL_POS_CN;
     machine_menu.LevelingAutoCommandConf = LEVELING_AUTO_COMMAND_CN;
-    machine_menu.LevelingAutoZoffsetConf = LEVELING_AUTO_ZOFFSET_CN;
-
+  	machine_menu.LevelingAutoZoffsetConf = LEVELING_AUTO_ZOFFSET_CN;
+    
     machine_menu.LevelingSubConfTitle = LEVELING_PARA_CONF_TITLE_CN;
     machine_menu.AutoLevelEnable      = AUTO_LEVELING_ENABLE_CN;
     machine_menu.BLtouchEnable        = BLTOUCH_LEVELING_ENABLE_CN;
@@ -280,6 +281,13 @@ void machine_setting_disp() {
     machine_menu.Yoffset         = OFFSET_Y_CN;
     machine_menu.Zoffset         = OFFSET_Z_CN;
 
+    machine_menu.LevelingTouchmiConf = LEVELING_TOUCHMI_CN;
+    machine_menu.TouchmiInit         = TM_INIT_CN;
+    machine_menu.TouchmiOffsetpos    = TM_ZOFFSETPOS_CN;
+    machine_menu.TouchmiOffsetneg    = TM_ZOFFSETNEG_CN;
+    machine_menu.TouchmiSave         = TM_SAVE_CN;
+    machine_menu.TouchmiTest         = TM_TEST_CN;
+    
     machine_menu.HomingSensitivityConfTitle = HOMING_SENSITIVITY_CONF_TITLE_CN;
     machine_menu.X_Sensitivity              = X_SENSITIVITY_CN;
     machine_menu.Y_Sensitivity              = Y_SENSITIVITY_CN;
@@ -352,7 +360,7 @@ void machine_setting_disp() {
     machine_menu.LevelingManuPosConf     = LEVELING_MANUAL_POS_T_CN;
     machine_menu.LevelingAutoCommandConf = LEVELING_AUTO_COMMAND_T_CN;
     machine_menu.LevelingAutoZoffsetConf = LEVELING_AUTO_ZOFFSET_T_CN;
-
+    
     machine_menu.LevelingSubConfTitle = LEVELING_PARA_CONF_TITLE_T_CN;
     machine_menu.AutoLevelEnable      = AUTO_LEVELING_ENABLE_T_CN;
     machine_menu.BLtouchEnable        = BLTOUCH_LEVELING_ENABLE_T_CN;
@@ -509,6 +517,13 @@ void machine_setting_disp() {
     machine_menu.Yoffset         = OFFSET_Y_T_CN;
     machine_menu.Zoffset         = OFFSET_Z_T_CN;
 
+    machine_menu.LevelingTouchmiConf = LEVELING_TOUCHMI_T_CN;
+    machine_menu.TouchmiInit         = TM_INIT_T_CN;
+    machine_menu.TouchmiOffsetpos    = TM_ZOFFSETPOS_T_CN;
+    machine_menu.TouchmiOffsetneg    = TM_ZOFFSETNEG_T_CN;
+    machine_menu.TouchmiSave         = TM_SAVE_T_CN;
+    machine_menu.TouchmiTest         = TM_TEST_T_CN;
+
     machine_menu.HomingSensitivityConfTitle = HOMING_SENSITIVITY_CONF_TITLE_T_CN;
     machine_menu.X_Sensitivity              = X_SENSITIVITY_T_CN;
     machine_menu.Y_Sensitivity              = Y_SENSITIVITY_T_CN;
@@ -581,7 +596,7 @@ void machine_setting_disp() {
     machine_menu.LevelingManuPosConf     = LEVELING_MANUAL_POS_EN;
     machine_menu.LevelingAutoCommandConf = LEVELING_AUTO_COMMAND_EN;
     machine_menu.LevelingAutoZoffsetConf = LEVELING_AUTO_ZOFFSET_EN;
-
+    
     machine_menu.LevelingSubConfTitle = LEVELING_PARA_CONF_TITLE_EN;
     machine_menu.AutoLevelEnable      = AUTO_LEVELING_ENABLE_EN;
     machine_menu.BLtouchEnable        = BLTOUCH_LEVELING_ENABLE_EN;
@@ -740,6 +755,13 @@ void machine_setting_disp() {
     machine_menu.Xoffset         = OFFSET_X_EN;
     machine_menu.Yoffset         = OFFSET_Y_EN;
     machine_menu.Zoffset         = OFFSET_Z_EN;
+
+    machine_menu.LevelingTouchmiConf = LEVELING_TOUCHMI_EN;
+    machine_menu.TouchmiInit         = TM_INIT_EN;
+    machine_menu.TouchmiOffsetpos    = TM_ZOFFSETPOS_EN;
+    machine_menu.TouchmiOffsetneg    = TM_ZOFFSETNEG_EN;
+    machine_menu.TouchmiSave         = TM_SAVE_EN;
+    machine_menu.TouchmiTest         = TM_TEST_EN;
 
     machine_menu.HomingSensitivityConfTitle = HOMING_SENSITIVITY_CONF_TITLE_EN;
     machine_menu.X_Sensitivity              = X_SENSITIVITY_EN;
@@ -1718,9 +1740,9 @@ void disp_language_init() {
             machine_menu.LevelingParaConfTitle   = LEVELING_CONF_TITLE_RU;
             machine_menu.LevelingParaConf        = LEVELING_PARA_CONF_RU;
             machine_menu.LevelingManuPosConf     = LEVELING_MANUAL_POS_RU;
-            machine_menu.LevelingAutoCommandConf = LEVELING_AUTO_COMMAND_RU;
-            machine_menu.LevelingAutoZoffsetConf = LEVELING_AUTO_ZOFFSET_RU;
-
+          	machine_menu.LevelingAutoCommandConf = LEVELING_AUTO_COMMAND_RU;
+          	machine_menu.LevelingAutoZoffsetConf = LEVELING_AUTO_ZOFFSET_RU;
+            
             machine_menu.AccelerationConfTitle = ACCELERATION_CONF_TITLE_RU;
             machine_menu.PrintAcceleration     = PRINT_ACCELERATION_RU;
             machine_menu.RetractAcceleration   = RETRACT_ACCELERATION_RU;
@@ -1774,6 +1796,13 @@ void disp_language_init() {
             machine_menu.Xoffset         = OFFSET_X_RU;
             machine_menu.Yoffset         = OFFSET_Y_RU;
             machine_menu.Zoffset         = OFFSET_Z_RU;
+
+            machine_menu.LevelingTouchmiConf = LEVELING_TOUCHMI_RU;
+            machine_menu.TouchmiInit         = TM_INIT_RU;
+            machine_menu.TouchmiOffsetpos    = TM_ZOFFSETPOS_RU;
+            machine_menu.TouchmiOffsetneg    = TM_ZOFFSETNEG_RU;
+            machine_menu.TouchmiSave         = TM_SAVE_RU;
+            machine_menu.TouchmiTest         = TM_TEST_RU;
 
             machine_menu.FilamentConfTitle   = FILAMENT_CONF_TITLE_RU;
             machine_menu.InLength            = FILAMENT_IN_LENGTH_RU;

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_multi_language.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_multi_language.h
@@ -106,6 +106,12 @@ typedef struct machine_common_disp{
   const char *LevelingManuPosConf;
   const char *LevelingAutoCommandConf;
   const char *LevelingAutoZoffsetConf;
+  const char *LevelingTouchmiConf;
+  const char *TouchmiInit;
+  const char *TouchmiOffsetpos;
+  const char *TouchmiOffsetneg;
+  const char *TouchmiSave;
+  const char *TouchmiTest;
 
   const char *LevelingSubConfTitle;
   const char *AutoLevelEnable;
@@ -375,6 +381,17 @@ typedef struct home_menu_disp {
 } home_menu_def;
 
 extern home_menu_def home_menu;
+
+typedef struct touchmi_menu_disp {
+  const char *title;
+  const char *init;
+  const char *zoffsetpos;
+  const char *zoffsetneg;
+  const char *test;
+  const char *save;
+} touchmi_menu_def;
+
+extern touchmi_menu_def touchmi_menu;
 
 typedef struct file_menu_disp {
   const char *title;
@@ -798,6 +815,13 @@ extern eeprom_def eeprom_menu;
 #define HOME_Z_TEXT         "Z"
 #define HOME_ALL_TEXT       "All"
 
+#define TM_INIT             "Init"
+#define TM_ZOFFSETPOS       "Offset +"
+#define TM_ZOFFSETNEG       "Offset -"
+#define TM_SAVE             "Save"
+#define TM_TEST             "Test"
+
+//#if defined(MKS_ROBIN_NANO)
 #define ABOUT_TYPE_TEXT     "MKS Robin Pro"
 
 #define ABOUT_VERSION_TEXT  "1.0.0"


### PR DESCRIPTION
### Requirements

For customers with TouchMI sensor leveling (www.hotends.fr)

### Description

Adding a menu on Config>Leveling Settings>Settings TouchMi Probe when TouchMi probe is select in configuration.h in Marlin.
With this menu you can initialize, tuning zoffset of sensor, save & test the sensor tuning


### Benefits

Easily adjust the TouchMI sensor from a single page, display the current Zoffset value on screen top during adjustment.
![1611479605376](https://user-images.githubusercontent.com/6730998/105625931-fa8c4200-5e2c-11eb-8bef-bc5b52950b33.jpg)


