### PR TITLE
robin nano v3 - reversed fan 1/2 pins

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -166,8 +166,8 @@
 #define HEATER_1_PIN                        PB0   // HEATER2
 #define HEATER_BED_PIN                      PA0   // HOT BED
 
-#define FAN_PIN                             PB1   // FAN
-#define FAN1_PIN                            PC14  // FAN1
+#define FAN_PIN                             PC14  // FAN0
+#define FAN1_PIN                            PB1   // FAN1
 
 //
 // Thermocouples


### PR DESCRIPTION
### Description

Fan 1 and Fan 2 reversed on Robin Nano v3. Pin mapping was reversed. "Fan 1"(silkscreen) = "FAN_PIN"(pins.h) should be PC14
![image](https://user-images.githubusercontent.com/27925441/111082144-fc38c480-84c3-11eb-9209-9560bf8112f4.png)


### Benefits

Fan settings should no longer be reversed

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
Any robin v3 config

