### PR TITLE
RobinNanov3 - PC14 (fan 0) doesn't seem to support HW PWM.

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -31,6 +31,10 @@
 
 #define BOARD_INFO_NAME "MKS Robin Nano V3"
 
+// Use soft PWM for fans - PWM is not working properly when paired with STM32 Arduino Core v1.7.0
+// This can be removed when Core version is updated and PWM behaviour is fixed.
+#define FAN_SOFT_PWM
+
 // USB Flash Drive support
 #define HAS_OTG_USB_HOST_SUPPORT
 


### PR DESCRIPTION
PC14 (fan 0) doesn't seem to support hardware PWM. Explanation Text copied from pins_RUMBA32_common.h
### Description

Software PWM is required for Fan 1 (silkscreen) / fan0 / PC14. Rumba32 also uses stm32f4 that seems to have the same problem. Without setting, PC14 is full power on or off with no control. PB1 (Fan 2) control works regardless.

### Benefits

fixes PWM for Fan 1 / PC14

### Configurations

Robin Nano v3