### PR TITLE
Add German keybord layout

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2420,14 +2420,17 @@
 
 #if ENABLED(TFT_LVGL_UI)
   #define MKS_WIFI_MODULE  // MKS WiFi module
+ 
   /**
-   * FRENCH KEYBOARD
+   * KEYBOARD LAYOUT
    * 
-   * Select the french keyboard layoud in MKS_UI
-   *  if defined  azerty layout
-   *  if npt      qwerty layout
+   * Select alternativ keyboard layout in MKS_UI
+   *  FRENCH_KEYBOARD - azerty layout
+   *  GERMAN_KEYBOARD - qwertz layout
+   *  if not defined - use qwerty layout
    */
   //#define FRENCH_KEYBOARD
+  #define GERMAN_KEYBOARD
 #endif
 
 /**

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_keyboard.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_keyboard.cpp
@@ -56,6 +56,29 @@ static const lv_btnm_ctrl_t kb_ctrl_uc_map[] = {
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     LV_KB_CTRL_BTN_FLAGS | 2, 2, 6, 2, LV_KB_CTRL_BTN_FLAGS | 2};
 
+#elif ENABLED(GERMAN_KEYBOARD)
+static const char * kb_map_lc[] = {"1#", "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", LV_SYMBOL_BACKSPACE, "\n",
+                                   "ABC", "a", "s", "d", "f", "g", "h", "j", "k", "l", LV_SYMBOL_NEW_LINE, "\n",
+                                   "_", "-", "y", "x", "c", "v", "b", "n", "m", ".", ",", ":", "\n",
+                                   LV_SYMBOL_CLOSE, LV_SYMBOL_LEFT, " ", LV_SYMBOL_RIGHT, LV_SYMBOL_OK, ""};
+
+static const lv_btnm_ctrl_t kb_ctrl_lc_map[] = {
+    LV_KB_CTRL_BTN_FLAGS | 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 7,
+    LV_KB_CTRL_BTN_FLAGS | 6, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    LV_KB_CTRL_BTN_FLAGS | 2, 2, 6, 2, LV_KB_CTRL_BTN_FLAGS | 2};
+
+static const char * kb_map_uc[] = {"1#", "Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P", LV_SYMBOL_BACKSPACE, "\n",
+                                   "abc", "A", "S", "D", "F", "G", "H", "J", "K", "L", LV_SYMBOL_NEW_LINE, "\n",
+                                   "_", "-", "Y", "X", "C", "V", "B", "N", "M", ".", ",", "^", "\n",
+                                   LV_SYMBOL_CLOSE, LV_SYMBOL_LEFT, " ", LV_SYMBOL_RIGHT, LV_SYMBOL_OK, ""};
+
+static const lv_btnm_ctrl_t kb_ctrl_uc_map[] = {
+    LV_KB_CTRL_BTN_FLAGS | 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 7,
+    LV_KB_CTRL_BTN_FLAGS | 6, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    LV_KB_CTRL_BTN_FLAGS | 2, 2, 6, 2, LV_KB_CTRL_BTN_FLAGS | 2};
+
 #else
 static const char * kb_map_lc[] = {"1#", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", LV_SYMBOL_BACKSPACE, "\n",
                                    "ABC", "a", "s", "d", "f", "g", "h", "j", "k", "l", LV_SYMBOL_NEW_LINE, "\n",


### PR DESCRIPTION
### Requirements

#define GERMAN_KEYBOARD in configuaration.h

### Description

<!--

you can now choose German or French, if nothing is defined use the default keybord layout

-->

### Benefits

Country-specific keyboard layout, more intuitive writing 
