### PR TITLE
Add printing time at print done in LVGL UI

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_dialog.cpp
@@ -321,6 +321,10 @@ void lv_draw_dialog(uint8_t type) {
   else if (DIALOG_IS(TYPE_FINISH_PRINT)) {
     lv_label_set_text(labelDialog, print_file_dialog_menu.print_finish);
     lv_obj_align(labelDialog, nullptr, LV_ALIGN_CENTER, 0, -20);
+
+    sprintf_P(public_buf_l, PSTR("%s: %d%d:%d%d:%d%d"), print_file_dialog_menu.print_time, print_time.hours / 10, print_time.hours % 10, print_time.minutes / 10, print_time.minutes % 10, print_time.seconds / 10, print_time.seconds % 10);
+    lv_obj_t *labelPrintTime = lv_label_create(scr, public_buf_l);
+    lv_obj_align(labelPrintTime, nullptr, LV_ALIGN_CENTER, 0, -60);
   }
   else if (DIALOG_IS(PAUSE_MESSAGE_PARKING)) {
     lv_label_set_text(labelDialog, pause_msg_menu.pausing);


### PR DESCRIPTION
### Description

Currently when a print finishes, is not possible to know the time it took to complete, in an unattended way. With this change,  the print time will be displayed in the "Print Finish" dialog.

### Related Issues

Issue #305 
